### PR TITLE
feat: add explicit Delete() methods for deterministic cleanup

### DIFF
--- a/delegates/delegates.go
+++ b/delegates/delegates.go
@@ -11,3 +11,9 @@ type ModifyGraphWithDelegater interface {
 type Delegater interface {
 	Ptr() unsafe.Pointer
 }
+
+// Deleter is an optional interface that delegates can implement
+// for deterministic native memory cleanup.
+type Deleter interface {
+	Delete()
+}

--- a/delegates/edgetpu/edgetpu.go
+++ b/delegates/edgetpu/edgetpu.go
@@ -65,6 +65,16 @@ func New(device Device) delegates.Delegater {
 	return del
 }
 
+// Delete frees the delegate immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (d *Delegate) Delete() {
+	if d.d != nil {
+		d.cleanup.Stop()
+		C.edgetpu_free_delegate(d.d)
+		d.d = nil
+	}
+}
+
 // Return a pointer
 func (d *Delegate) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(d.d)

--- a/delegates/external/external.go
+++ b/delegates/external/external.go
@@ -64,6 +64,16 @@ func New(options DelegateOptions) delegates.Delegater {
 	return del
 }
 
+// Delete frees the delegate immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (d *Delegate) Delete() {
+	if d.d != nil {
+		d.cleanup.Stop()
+		C.TfLiteExternalDelegateDelete(d.d)
+		d.d = nil
+	}
+}
+
 // Return a pointer
 func (d *Delegate) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(d.d)

--- a/delegates/gpu/cl/cl.go
+++ b/delegates/gpu/cl/cl.go
@@ -59,6 +59,16 @@ func New(options *GpuDelegateOptions) delegates.Delegater {
 	return del
 }
 
+// Delete frees the delegate immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (g *GpuDelegate) Delete() {
+	if g.d != nil {
+		g.cleanup.Stop()
+		C.TfLiteGpuDelegateDelete_New(g.d)
+		g.d = nil
+	}
+}
+
 func (g *GpuDelegate) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(g.d)
 }

--- a/delegates/gpu/gl/gl.go
+++ b/delegates/gpu/gl/gl.go
@@ -60,6 +60,16 @@ func New(options *GpuDelegateOptions) delegates.Delegater {
 	return del
 }
 
+// Delete frees the delegate immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (g *GpuDelegate) Delete() {
+	if g.d != nil {
+		g.cleanup.Stop()
+		C.TfLiteGpuDelegateDelete(g.d)
+		g.d = nil
+	}
+}
+
 func (g *GpuDelegate) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(g.d)
 }

--- a/delegates/lib/lib.go
+++ b/delegates/lib/lib.go
@@ -76,9 +76,14 @@ func New(libraryPath string) delegates.Delegater {
 	return &LibDelegate{d: d, destroyFunc: destroyFunc, libHandle: h}
 }
 
+// Delete frees the delegate immediately.
+// Safe to call multiple times.
 func (d *LibDelegate) Delete() {
-	C.destroyDelegate(d.destroyFunc, d.d)
-	d.libHandle.Close()
+	if d.d != nil {
+		C.destroyDelegate(d.destroyFunc, d.d)
+		d.d = nil
+		d.libHandle.Close()
+	}
 }
 
 func (d *LibDelegate) Ptr() unsafe.Pointer {

--- a/delegates/xnnpack/xnnpack.go
+++ b/delegates/xnnpack/xnnpack.go
@@ -45,6 +45,16 @@ func New(options DelegateOptions) delegates.Delegater {
 	return del
 }
 
+// Delete frees the delegate immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (d *Delegate) Delete() {
+	if d.d != nil {
+		d.cleanup.Stop()
+		C.TfLiteXNNPackDelegateDelete(d.d)
+		d.d = nil
+	}
+}
+
 // Return a pointer
 func (d *Delegate) Ptr() unsafe.Pointer {
 	return unsafe.Pointer(d.d)

--- a/tflite.go
+++ b/tflite.go
@@ -155,6 +155,9 @@ func (o *InterpreterOptions) AddDelegate(d delegates.Delegater) {
 }
 
 // Delete frees the options and any associated delegates immediately rather than waiting for GC.
+// This assumes exclusive ownership of the delegates — do not call if delegates are shared
+// with other InterpreterOptions instances. For shared delegates, call Delete() on each
+// resource individually.
 // Safe to call multiple times.
 func (o *InterpreterOptions) Delete() {
 	if o.o != nil {
@@ -202,6 +205,11 @@ func NewInterpreter(model *Model, options *InterpreterOptions) *Interpreter {
 // Delete frees the interpreter, its options (including delegates), and model immediately
 // rather than waiting for GC. Resources are freed in the correct order:
 // interpreter first, then options and delegates, then model.
+//
+// This assumes the interpreter has exclusive ownership of its model and options.
+// If a model or options are shared across multiple interpreters, do not use this method —
+// instead call Delete() on each resource individually in the correct order
+// (all interpreters first, then options, then model).
 // Safe to call multiple times.
 func (i *Interpreter) Delete() {
 	if i.i != nil {

--- a/tflite.go
+++ b/tflite.go
@@ -85,6 +85,20 @@ type modelCleanupData struct {
 	buf unsafe.Pointer
 }
 
+// Delete frees the model and its buffer immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (m *Model) Delete() {
+	if m.m != nil {
+		m.cleanup.Stop()
+		C.TfLiteModelDelete(m.m)
+		if m.buf != nil {
+			C.free(m.buf)
+			m.buf = nil
+		}
+		m.m = nil
+	}
+}
+
 // NewModelFromFile create new Model from file data.
 func NewModelFromFile(model_path string) *Model {
 	ptr := C.CString(model_path)
@@ -140,6 +154,22 @@ func (o *InterpreterOptions) AddDelegate(d delegates.Delegater) {
 	C.TfLiteInterpreterOptionsAddDelegate(o.o, (*C.TfLiteDelegate)(d.Ptr()))
 }
 
+// Delete frees the options and any associated delegates immediately rather than waiting for GC.
+// Safe to call multiple times.
+func (o *InterpreterOptions) Delete() {
+	if o.o != nil {
+		o.cleanup.Stop()
+		C.TfLiteInterpreterOptionsDelete(o.o)
+		o.o = nil
+	}
+	for _, d := range o.delegates {
+		if del, ok := d.(delegates.Deleter); ok {
+			del.Delete()
+		}
+	}
+	o.delegates = nil
+}
+
 // Interpreter implement TfLiteInterpreter.
 type Interpreter struct {
 	i       *C.TfLiteInterpreter
@@ -167,6 +197,26 @@ func NewInterpreter(model *Model, options *InterpreterOptions) *Interpreter {
 		C.TfLiteInterpreterDelete(ptr)
 	}, i)
 	return interp
+}
+
+// Delete frees the interpreter, its options (including delegates), and model immediately
+// rather than waiting for GC. Resources are freed in the correct order:
+// interpreter first, then options and delegates, then model.
+// Safe to call multiple times.
+func (i *Interpreter) Delete() {
+	if i.i != nil {
+		i.cleanup.Stop()
+		C.TfLiteInterpreterDelete(i.i)
+		i.i = nil
+	}
+	if i.options != nil {
+		i.options.Delete()
+		i.options = nil
+	}
+	if i.model != nil {
+		i.model.Delete()
+		i.model = nil
+	}
 }
 
 // Tensor implement TfLiteTensor.


### PR DESCRIPTION
## Summary

- Add idempotent `Delete()` methods to `Interpreter`, `Model`, `InterpreterOptions`, and all delegate types for immediate native memory cleanup
- Add `delegates.Deleter` interface for type-safe delegate cleanup from `InterpreterOptions.Delete()`
- `Interpreter.Delete()` cascades in correct teardown order: interpreter -> options+delegates -> model
- Existing `runtime.AddCleanup`-based GC cleanup continues to work for callers that don't call `Delete()`

## Test plan

- [ ] Verify `Delete()` is idempotent (calling twice doesn't panic)
- [ ] Verify `cleanup.Stop()` prevents double-free when GC runs after explicit `Delete()`
- [ ] Verify `Interpreter.Delete()` cascade frees all resources in correct order
- [ ] Verify callers that don't call `Delete()` still get GC-based cleanup

Closes #20

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added explicit Delete methods across models, interpreters, options and delegates to allow deterministic immediate resource release instead of waiting for garbage collection.
  * Interpreter options now proactively free attached delegates when deleted.
  * All Delete methods are idempotent and safe to call multiple times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->